### PR TITLE
Add threads to snakemake, allow parallel jobs to be launched within thread limit

### DIFF
--- a/bin/ntSynt.py
+++ b/bin/ntSynt.py
@@ -42,13 +42,14 @@ def main():
         args.prefix = f"ntSynt.k{args.k}.w{args.w}"
 
     args.w_rounds = " ".join(map(str, args.w_rounds))
-    command = f"snakemake -s {base_dir}/ntsynt_run_pipeline.smk -p --cores 1 " \
+    command = f"snakemake -s {base_dir}/ntsynt_run_pipeline.smk -p --cores {args.t} " \
                 f"--config references='{args.fastas}' k={args.k} w={args.w} t={args.t} fpr={args.fpr} " \
                 f"prefix={args.prefix} w_rounds='{args.w_rounds}' indel_merge={args.indel} " \
                 f"collinear_merge={args.merge}w "
     command += "solid=False " if args.no_solid else "solid=True "
     command += "simplify_graph=False " if args.no_simplify_graph else "simplify_graph=True "
     command += "benchmark=True " if args.benchmark else "benchmark=False "
+    command += "--resources load=2 " # For indexlr, don't want more than 2 indexlr at a time due to memory
 
     if args.dry_run:
         command += " -n"

--- a/bin/ntsynt_run_pipeline.smk
+++ b/bin/ntsynt_run_pipeline.smk
@@ -11,7 +11,7 @@ references = config["references"] if "references" in config else "Must specify '
 k = config["k"] if "k" in config else 24
 w = config["w"] if "w" in config else 1000
 fpr = config["fpr"] if "fpr" in config else 0.025
-threads = config["t"] if "t" in config else 4
+max_threads = config["t"] if "t" in config else 4
 prefix = config["prefix"] if "prefix" in config else "ntSynt_out"
 solid = config["solid"] if "solid" in config else True
 repeat = config["repeat"] if "repeat" in config else False
@@ -44,35 +44,40 @@ rule faidx:
     input: fa="{file}"
     output: "{file}.fai"
     params: benchmarking=expand("{benchmark_path} -o {{file}}.faidx.time", benchmark_path=benchmark_path) if benchmark else []
+    threads: 1
     shell: "{params.benchmarking} samtools faidx {input.fa}"
 
 rule make_solid_bf:
     input: refs=references
     output: expand("{prefix}.solid.bf", prefix=prefix)
-    params: options=expand("-p {prefix}.solid --fpr {fpr} -k {k} -t {threads}", prefix=prefix, fpr=fpr, k=k, threads=threads),
+    threads: max_threads
+    params: options=expand("-p {prefix}.solid --fpr {fpr} -k {k}", prefix=prefix, fpr=fpr, k=k),
             path_to_script=expand("{base_path}/ntsynt_make_solid_bf", base_path=script_path),
             benchmarking=expand("{benchmark_path} -o {prefix}.make_solid_bf.time", benchmark_path=benchmark_path, prefix=prefix) if benchmark else []
-    shell: "{params.benchmarking} {params.path_to_script} --genome {input.refs} {params.options}"
+    shell: "{params.benchmarking} {params.path_to_script} --genome {input.refs} {params.options} -t {threads}"
 
 # For posterity, included but this is experimental
 rule make_repeat_bf:
     input: refs=references
     output: expand("{prefix}.repeat.bf", prefix=prefix)
-    params: options=expand("-p {prefix}.repeat --fpr {fpr} -k {k} -t {threads}", prefix=prefix, fpr=fpr, k=k, threads=threads),
+    threads: max_threads
+    params: options=expand("-p {prefix}.repeat --fpr {fpr} -k {k}", prefix=prefix, fpr=fpr, k=k),
             path_to_script=expand("{base_path}/ntsynt_make_repeat_bfs.py", base_path=script_path),
             benchmarking=expand("{benchmark_path} -o {prefix}.make_repeat_bf.time", benchmark_path=benchmark_path, prefix=prefix) if benchmark else []
-    shell: "{params.benchmarking} {params.path_to_script} --genome {input.refs} {params.options}"
+    shell: "{params.benchmarking} {params.path_to_script} --genome {input.refs} {params.options} -t {threads}"
 
 rule indexlr:
     input: fa="{fasta}",
             solid=expand("{prefix}.solid.bf", prefix=prefix) if solid is True else [],
             repeat=expand("{prefix}.repeat.bf", prefix=prefix) if repeat is True else []
     output: expand("{{fasta}}.k{k}.w{w}.tsv", k=k, w=w)
-    params: options=expand("-k {k} -w {w} -t {t} --long --seq --pos", k=k, w=w, t=threads),
+    threads: 5
+    resources: load=1
+    params: options=expand("-k {k} -w {w} --long --seq --pos", k=k, w=w),
             bf="-s" if solid is True else [],
             repeat="-r" if repeat is True else [],
             benchmarking=expand("{benchmark_path} -o {{fasta}}.indexlr.time", benchmark_path=benchmark_path) if benchmark else []
-    shell: "{params.benchmarking} indexlr {params.options} {params.bf} {input.solid} {params.repeat} {input.repeat} {input.fa} > {output}"
+    shell: "{params.benchmarking} indexlr {params.options} -t {threads} {params.bf} {input.solid} {params.repeat} {input.repeat} {input.fa} > {output}"
 
 rule ntsynt_synteny:
     input: mx=expand("{fasta}.k{k}.w{w}.tsv", fasta=references, k=k, w=w),
@@ -80,6 +85,7 @@ rule ntsynt_synteny:
             repeat=expand("{prefix}.repeat.bf", prefix=prefix) if repeat is True else [],
             fais=expand("{fasta}.fai", fasta=references)
     output: expand("{prefix}.synteny_blocks.tsv", prefix=prefix)
+    threads: max_threads
     params: path_to_script=expand("{base_path}/ntsynt_run.py", base_path=script_path),
             options=expand("-k {k} -w {w} --w-rounds {w_rounds} -p {prefix} --bp {indel_merge} --collinear-merge {collinear_merge}",
                             k=k, w=w, w_rounds=[w_rounds], prefix=prefix, indel_merge=indel_merge, collinear_merge=collinear_merge),
@@ -88,4 +94,4 @@ rule ntsynt_synteny:
             simplify_graph="--simplify-graph" if simplify_graph is True else [],
             benchmarking=expand("{benchmark_path} -o {prefix}.synteny_blocks.time", benchmark_path=benchmark_path, prefix=prefix) if benchmark else [] 
     shell: "{params.benchmarking} python3 {params.path_to_script} {input.mx} {params.options} {params.solid_bf} {input.solid}  {params.simplify_graph} \
-             {params.repeat_bf} {input.repeat}"
+             --btllib_t {threads} {params.repeat_bf} {input.repeat}"


### PR DESCRIPTION
* Set-up snakemake to allow parallel jobs while still adhering to the number of specified threads by the user
* For indexlr jobs, regardless of threads specified, only allow two to run at a time
  * This is to control the memory - since the Bloom filter needs to be loaded for each indexlr job too. When creating the solid BF, we have 2xBF size in memory, so by having this constraint, we will not be ballooning the memory too much
* Also for indexlr jobs, they do not scale past 5 threads, so use this hard threshold for number of threads used for indexlr, regardless of the specified number 