### PR TITLE
Add some grace for overlapping synteny blocks

### DIFF
--- a/bin/ntsynt_synteny.py
+++ b/bin/ntsynt_synteny.py
@@ -463,8 +463,6 @@ class NtSyntSynteny(ntjoin.Ntjoin):
             paths = self.check_for_indels(paths)
             paths = self.filter_synteny_blocks(paths, 4) # TODO: magic number
             paths_sorted_for_printing = sorted(paths)
-            if new_w == self.args.w_rounds[-1]: # Do final check for last w round
-                self.check_non_overlapping(paths)
             with open(f"{self.args.p}.pre-collinear-merge.synteny_blocks.tsv", 'w', encoding="utf-8") as outfile:
                 block_num = 0
                 for block in paths_sorted_for_printing:
@@ -475,6 +473,7 @@ class NtSyntSynteny(ntjoin.Ntjoin):
                     block_num += 1
             if new_w == self.args.w_rounds[-1]:
                 paths_sorted_for_printing_collinear = self.merge_collinear_blocks(paths_sorted_for_printing)
+                self.check_non_overlapping(paths_sorted_for_printing_collinear) # Check for non-overlapping in this last round
                 with open(f"{self.args.p}.synteny_blocks.tsv", 'w', encoding="utf-8") as outfile:
                     block_num = 0
                     for block in paths_sorted_for_printing_collinear:


### PR DESCRIPTION
* There is code in ntSynt to print a warning if an overlap is detected between synteny blocks
* But, when I looked at examples, they were generally very small (<5bp) overlaps
  * I don't think this is a concern
* The intention of the warning is to have logic in there to identify when synteny blocks have very large overlaps (which could indicate an issue)
  * I thought that having these warnings printing when there really wasn't any concern confusing
* So, implemented a check where the warning is only printed out if the overlap is large (over -z, default 500bp) 