### PR TITLE
Add --fastas_list to ntSynt

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ Lauren Coombe, Parham Kazemi, Johnathan Wong, Inanc Birol, René L. Warren. Mult
 ## Usage
 
 ```
-usage: ntSynt [-h] -d DIVERGENCE [-p PREFIX] [-k K] [-w W] [-t T] [--fpr FPR] [-b BLOCK_SIZE] [--merge MERGE] [--w_rounds W_ROUNDS [W_ROUNDS ...]]
-                 [--indel INDEL] [-n] [--benchmark] [-f] [--dev] [-v]
-                 fastas [fastas ...]
+usage: ntSynt [-h] [--fastas_list FASTAS_LIST] -d DIVERGENCE [-p PREFIX] [-k K] [-w W] [-t T] [--fpr FPR] [-b BLOCK_SIZE] [--merge MERGE]
+              [--w_rounds W_ROUNDS [W_ROUNDS ...]] [--indel INDEL] [-n] [--benchmark] [-f] [--dev] [-v]
+              [fastas ...]
 
 ntSynt: Multi-genome synteny detection using minimizer graphs
 
@@ -62,6 +62,8 @@ positional arguments:
 
 optional arguments:
   -h, --help            show this help message and exit
+  --fastas_list FASTAS_LIST
+                        File listing input genome fasta files, one per line
   -d DIVERGENCE, --divergence DIVERGENCE
                         Approx. maximum percent sequence divergence between input genomes (Ex. -d 1 for 1% divergence).
                         This will be used to set --indel, --merge, --w_rounds, --block_size

--- a/bin/ntSynt
+++ b/bin/ntSynt
@@ -22,6 +22,14 @@ NTSYNT_ASCII = """
                     |___/   
 """
 
+def read_fasta_files(filename):
+    "Read in fasta files in the specified file"
+    fastas = []
+    with open(filename, 'r', encoding="utf-8") as fin:
+        for fasta in fin:
+            fastas.append(fasta.strip())
+    return fastas
+
 def main():
     "Run ntSynt snakemake file"
 
@@ -35,7 +43,9 @@ def main():
     parser = argparse.ArgumentParser(description="ntSynt: Multi-genome synteny detection using minimizer graphs",
                                      formatter_class=argparse.RawTextHelpFormatter,
                                      epilog=epilog_str)
-    parser.add_argument("fastas", help="Input genome fasta files", nargs="+")
+    parser.add_argument("fastas", help="Input genome fasta files", nargs="*")
+    parser.add_argument("--fastas_list", help="File listing input genome fasta files, one per line",
+                        required=False, type=str)
     parser.add_argument("-d", "--divergence",
                         help="Approx. maximum percent sequence divergence between input genomes"\
                             " (Ex. -d 1 for 1%% divergence).\n"\
@@ -93,14 +103,27 @@ def main():
         if w > args.w:
             parser.error("All values specified for --w_rounds must be smaller than -w")
 
-    if len(args.fastas) < 2:
+    if not args.fastas and not args.fastas_list:
+        parser.error("Please supply the input genome fasta files as positional arguments, " \
+                     "or specify a file listing the files (one fasta per line) with --fastas_list")
+
+    if args.fastas and args.fastas_list:
+        parser.error("Please supply the input genome fasta files as positional arguments, "\
+                    "or specify a single file (one fasta per line) with --fastas_list, NOT both.")
+
+    if args.fastas_list:
+        fastas_input = read_fasta_files(args.fastas_list)
+    else:
+        fastas_input = args.fastas
+
+    if len(fastas_input) < 2:
         parser.error("Must supply at least two reference genomes to compare")
 
     print(NTSYNT_ASCII)
     intro_string = ["Running ntSynt...",
                     f"Specified percent divergence: {args.divergence}",
                     "Parameter settings:",
-                    f"\tfastas {args.fastas}",
+                    f"\tfastas {fastas_input}",
                     f"\t--divergence {args.divergence}",
                     f"\t--block_size {args.block_size}",
                     f"\t--merge {args.merge}",
@@ -115,13 +138,13 @@ def main():
     print("\n".join(intro_string), flush=True)
 
     # Check that the input fastas exist
-    for fasta in args.fastas:
+    for fasta in fastas_input:
         if not os.path.isfile(fasta):
             raise FileNotFoundError(f"Input file {fasta} not found.")
 
     args.w_rounds = " ".join(map(str, args.w_rounds))
     command = f"snakemake -s {base_dir}/ntsynt_run_pipeline.smk -p --cores {args.t} " \
-                f"--config references='{args.fastas}' k={args.k} w={args.w} t={args.t} fpr={args.fpr} " \
+                f"--config references='{fastas_input}' k={args.k} w={args.w} t={args.t} fpr={args.fpr} " \
                 f"prefix={args.prefix} w_rounds='{args.w_rounds}' indel_merge={args.indel} " \
                 f"collinear_merge={args.merge} block_size={args.block_size} "
     command += "common=False " if args.no_common else "common=True "

--- a/bin/ntSynt
+++ b/bin/ntSynt
@@ -23,7 +23,7 @@ NTSYNT_ASCII = """
 """
 
 def read_fasta_files(filename):
-    "Read in fasta files in the specified file"
+    "Read in fasta file names in the specified file"
     fastas = []
     with open(filename, 'r', encoding="utf-8") as fin:
         for fasta in fin:

--- a/tests/genome_file_list.tsv
+++ b/tests/genome_file_list.tsv
@@ -1,0 +1,3 @@
+celegans-chrII-III.fa
+celegans-chrII-III.A.fa
+celegans-chrII-III.B.fa

--- a/tests/ntsynt_tests.py
+++ b/tests/ntsynt_tests.py
@@ -14,6 +14,14 @@ def launch_ntSynt(*genomes, prefix="ntSynt", k=24, w=1000, **kwargs):
     ret_code = subprocess.call(cmd)
     assert ret_code == 0
 
+def launch_ntSynt_fof(genome_file_list, prefix="ntSynt", k=24, w=1000, **kwargs):
+    "Launch ntSynt"
+    more_params = " ".join(f"--{name} {val}" for name, val in kwargs.items())
+    cmd = f"ntSynt --force --fastas_list {genome_file_list} -k{k} -w {w} -d 0.5 --prefix {prefix} {more_params}"
+    cmd = shlex.split(cmd)
+    ret_code = subprocess.call(cmd)
+    assert ret_code == 0
+
 def are_expected_blocks(block_file1, block_file2):
     "Check that the given synteny blocks are as expected"
     with open(block_file1, 'r', encoding="utf-8") as fin1:
@@ -41,6 +49,13 @@ def test_3_genomes():
     genome1, genome2, genome3 = "celegans-chrII-III.fa", "celegans-chrII-III.A.fa", "celegans-chrII-III.B.fa"
     launch_ntSynt(genome1, genome2, genome3, k=20, prefix="celegans-A-B-ntSynt", indel=500, merge=3000)
     are_expected_blocks("celegans-A-B-ntSynt.synteny_blocks.tsv",
+                        "expected_result/celegans-A-B-ntSynt.synteny_blocks.tsv")
+
+def test_3_genomes_fof():
+    "Testing ntSynt with three input genomes, specified using a file of files"
+    genome_list = "genome_file_list.tsv"
+    launch_ntSynt_fof(genome_list, k=20, prefix="celegans-A-B-ntSynt-fof", indel=500, merge=3000)
+    are_expected_blocks("celegans-A-B-ntSynt-fof.synteny_blocks.tsv",
                         "expected_result/celegans-A-B-ntSynt.synteny_blocks.tsv")
 
 def test_cleanup():


### PR DESCRIPTION
* Allows for the genome files to be supplied in a file (one file per line), instead of listing on the command-line as positional arguments
  * This parameter cannot be combined with using the positional arguments for fasta files
* Add --fastas_list test
* Update README.md