### PR TITLE
Fixes for gggenomes visualization scripts

### DIFF
--- a/visualization_scripts/format_blocks_gggenomes.sh
+++ b/visualization_scripts/format_blocks_gggenomes.sh
@@ -23,4 +23,3 @@ sort_ntsynt_blocks.py --synteny_blocks ${synteny_tsv} --sort_order ${fais} --fai
 format_blocks_gggenomes.py --fai ${fais} --prefix ${prefix} --blocks ${prefix}.synteny_blocks.sorted.tsv \
     --length ${length_threshold} --colour ${target_colour}
 cat ${prefix}.links.tsv  |mlr --tsv sort -f strand -n block_id > ${prefix}.links.sorted.tsv && mv ${prefix}.links.sorted.tsv ${prefix}.links.tsv
-cat ${prefix}.sequence_lengths.tsv |mlr --tsv sort -f seq_id > ${prefix}.sequence_lengths.sorted.tsv && mv ${prefix}.sequence_lengths.sorted.tsv ${prefix}.sequence_lengths.tsv

--- a/visualization_scripts/plot_synteny_blocks_gggenomes.R
+++ b/visualization_scripts/plot_synteny_blocks_gggenomes.R
@@ -23,9 +23,10 @@ args <- parser$parse_args()
 sequences <- read.csv(args$sequences, sep = "\t", header = TRUE)
 
 # https://stackoverflow.com/questions/32378108/using-gtoolsmixedsort-or-alternatives-with-dplyrarrange
+input_order <- unique(sequences$bin_id)
 mixedrank <- function(x) order(gtools::mixedorder(x))
 sequences <- sequences %>%
-  arrange(mixedrank(seq_id))
+  arrange(factor(bin_id, levels=input_order), mixedrank(seq_id))
 
 
 # Read in and prepare synteny links

--- a/visualization_scripts/sort_ntsynt_blocks.py
+++ b/visualization_scripts/sort_ntsynt_blocks.py
@@ -4,6 +4,7 @@ Sort the assemblies within each synteny block in the specified order.
 Assumes ntSynt-formatted synteny blocks
 '''
 import argparse
+import os
 import re
 from collections import namedtuple
 
@@ -49,7 +50,7 @@ def main():
     args = parser.parse_args()
 
     if args.fais:
-        sort_order_dict = {re.search(faidx_re, asm).group(1): i for i, asm in enumerate(args.sort_order)}
+        sort_order_dict = {re.search(faidx_re, os.path.basename(os.path.realpath(asm))).group(1): i for i, asm in enumerate(args.sort_order)}
     else:
         sort_order_dict = {asm: i for i, asm in enumerate(args.sort_order)}
 


### PR DESCRIPTION
* Fix sorting order for ribbon plots
  * With some file names and orders, the assemblies were plotted out of order, which lead to ribbons being missing erroneously
* Fix for input FAI files for the gggenomes prep scripts being in directories other than the current working directory
  * Previously, was assumed there was no path specified, but with fix, the FAI files can be located anywhere