### PR TITLE
Fix to remove SyntaxWarning

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,8 +19,8 @@ jobs:
 
   - script: |
       source activate ntsynt_ci
-      conda install --yes -c bioconda -c conda-forge python=3.10 mamba
-      mamba install --yes -c bioconda -c conda-forge intervaltree pybedtools ncls python-igraph compilers btllib=1.6.2 meson ninja snakemake samtools pytest seqtk pylint
+      conda install --yes -c bioconda -c conda-forge python mamba
+      mamba install --yes -c bioconda -c conda-forge intervaltree pybedtools ncls python-igraph compilers btllib meson ninja snakemake samtools pytest seqtk pylint
     displayName: Install dependencies
 
   - script: |
@@ -66,8 +66,8 @@ jobs:
 
   - script: |
       source activate ntsynt_ci
-      conda install --yes -c bioconda -c conda-forge python=3.10 mamba
-      mamba install --yes -c bioconda -c conda-forge intervaltree pybedtools ncls python-igraph compilers  btllib=1.6.2 meson ninja snakemake samtools pytest seqtk
+      conda install --yes -c bioconda -c conda-forge python mamba
+      mamba install --yes -c bioconda -c conda-forge intervaltree pybedtools ncls python-igraph compilers  btllib meson ninja snakemake samtools pytest seqtk
     displayName: Install dependencies
 
   - script: |

--- a/bin/ntSynt
+++ b/bin/ntSynt
@@ -13,7 +13,7 @@ import snakemake
 
 NTSYNT_VERSION = "ntSynt v1.0.1"
 
-NTSYNT_ASCII = """
+NTSYNT_ASCII = r"""
         _    ____                 _ 
  _ __  | |_ / ___|  _   _  _ __  | |_ 
 | '_ \ | __|\___ \ | | | || '_ \ | __|

--- a/bin/synteny_block.py
+++ b/bin/synteny_block.py
@@ -114,4 +114,4 @@ class SyntenyBlock:
             if block != other.self.assembly_blocks[assembly]:
                 is_equal = False
         return is_equal
-        
+

--- a/bin/synteny_block.py
+++ b/bin/synteny_block.py
@@ -114,4 +114,3 @@ class SyntenyBlock:
             if block != other.self.assembly_blocks[assembly]:
                 is_equal = False
         return is_equal
-


### PR DESCRIPTION
* With python 3.12, a SyntaxWarning was printed out when the `ntSynt` script was being printed out
  * This fixes the warning by specifying the ntSynt ascii art as a raw string literal