### PR TITLE
Use multi-character config keys to fix error with snakemake v8.17.0

### DIFF
--- a/bin/ntSynt
+++ b/bin/ntSynt
@@ -144,7 +144,7 @@ def main():
 
     args.w_rounds = " ".join(map(str, args.w_rounds))
     command = f"snakemake -s {base_dir}/ntsynt_run_pipeline.smk -p --cores {args.t} " \
-                f"--config references='{fastas_input}' k={args.k} w={args.w} t={args.t} fpr={args.fpr} " \
+                f"--config references='{fastas_input}' kmer={args.k} window={args.w} threads={args.t} fpr={args.fpr} " \
                 f"prefix={args.prefix} w_rounds='{args.w_rounds}' indel_merge={args.indel} " \
                 f"collinear_merge={args.merge} block_size={args.block_size} "
     command += "common=False " if args.no_common else "common=True "

--- a/bin/ntsynt_run_pipeline.smk
+++ b/bin/ntsynt_run_pipeline.smk
@@ -8,10 +8,10 @@ onsuccess:
 
 # Read in parameters
 references = config["references"] if "references" in config else "Must specify 'references'"
-k = config["k"] if "k" in config else 24
-w = config["w"] if "w" in config else 1000
+k = config["kmer"] if "kmer" in config else 24
+w = config["window"] if "window" in config else 1000
 fpr = config["fpr"] if "fpr" in config else 0.025
-max_threads = config["t"] if "t" in config else 4
+max_threads = config["threads"] if "threads" in config else 4
 prefix = config["prefix"] if "prefix" in config else "ntSynt_out"
 common = config["common"] if "common" in config else True
 repeat = config["repeat"] if "repeat" in config else False


### PR DESCRIPTION
* With v8.17.0 of snakemake, was getting this error:
```
snakemake -s /Users/lcoombe/Documents/GSC/miniconda3/envs/test/bin/ntsynt_run_pipeline.smk -p --cores 12 --config references='['celegans-chrII-III.fa', 'celegans-chrII-III.A.fa']' k=24 w=1000 t=12 fpr=0.025 prefix=celegans-A-ntSynt w_rounds='100 10' indel_merge=500 collinear_merge=3000 block_size=500 common=True simplify_graph=True benchmark=False dev=False --resources load=2 --rerun-trigger mtime 
Traceback (most recent call last):

  File "/Users/lcoombe/Documents/GSC/miniconda3/envs/test/lib/python3.12/site-packages/snakemake/cli.py", line 1998, in args_to_api
    config=parse_config(args.config),
           ^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/Users/lcoombe/Documents/GSC/miniconda3/envs/test/lib/python3.12/site-packages/snakemake/cli.py", line 256, in parse_config
    raise ValueError(

ValueError: Invalid config definition: Config entry must start with a valid identifier.
```
* Looks to be related to single-character config keys not being supported in this new version
* As a workaround, used multi-character keys for all parameters to the snakemake file
  * The `ntSynt` usage itself is unchanged - only a change under the hood