### PR TITLE
Fix macOS CI - install conda via miniforge

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -58,15 +58,22 @@ jobs:
     persistCredentials: true
     submodules: true
 
-  - script: echo "##vso[task.prependpath]$CONDA/bin"
-    displayName: Add conda to PATH
+  - script: |
+      mkdir -p ~/miniforge3
+      curl -L https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-x86_64.sh  -o ~/miniforge3/miniforge.sh
+      bash ~/miniforge3/miniforge.sh -b -u -p ~/miniforge3
+      rm -rf  ~/miniforge3/miniforge.sh
+      ~/miniforge3/bin/conda init bash
+      ~/miniforge3/bin/conda init zsh
+      export CONDA=$(realpath ~/miniforge3/bin)
+      echo "##vso[task.prependpath]$CONDA"
+    displayName: Install conda
 
   - script: conda create --yes --quiet --name ntsynt_ci
     displayName: Create Anaconda environment
 
   - script: |
       source activate ntsynt_ci
-      conda install --yes -c bioconda -c conda-forge python mamba
       mamba install --yes -c bioconda -c conda-forge intervaltree pybedtools ncls python-igraph compilers  btllib meson ninja snakemake samtools pytest seqtk
     displayName: Install dependencies
 

--- a/bin/.pylintrc
+++ b/bin/.pylintrc
@@ -9,6 +9,7 @@ max-public-methods=50
 max-statements = 70 
 max-module-lines = 1500
 max-bool-expr = 7
+max-positional-arguments = 6
  
 [MISCELLANEOUS]
 

--- a/bin/ntsynt_synteny.py
+++ b/bin/ntsynt_synteny.py
@@ -191,7 +191,8 @@ class NtSyntSynteny(ntjoin.Ntjoin):
                 self.delete_w_iteration_files(indexlr_filename, assembly_masked, f"{assembly_masked}.tmp")
         return list_mxs, new_list_mxs_info
 
-    def update_intervals(self, assembly_name, ctg, mx1, mx2, intervals):
+    @staticmethod
+    def update_intervals(assembly_name, ctg, mx1, mx2, intervals):
         "Update the given dictionary of trees with the new extent"
         start_pos = min(mx1.position, mx2.position)
         end_pos = max(mx1.position, mx2.position)


### PR DESCRIPTION
* Recently, macOS-latest VM was updated to use macOS-14
  * This VM no longer has conda installed by default
* Workaround is to install miniforge as part of the CI
  * This already has mamba, which is a side benefit
* Also, fixes for pylint 