### PR TITLE
Fix CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,7 +19,7 @@ jobs:
 
   - script: |
       source activate ntsynt_ci
-      conda install --yes -c bioconda -c conda-forge python mamba
+      conda install --yes -c bioconda -c conda-forge python=3.12 mamba
       mamba install --yes -c bioconda -c conda-forge intervaltree pybedtools ncls python-igraph compilers btllib meson ninja snakemake samtools pytest seqtk pylint
     displayName: Install dependencies
 


### PR DESCRIPTION
* Pin python version for linux  
  * Due to default python 3.13 not having bioconda package builds yet