### PR TITLE
Retain snakemake metadata run files

### DIFF
--- a/bin/ntsynt_run_pipeline.smk
+++ b/bin/ntsynt_run_pipeline.smk
@@ -3,8 +3,8 @@ import shutil
 import sys
 import os
 
-onsuccess:
-    shutil.rmtree(".snakemake", ignore_errors=True)
+# onsuccess:
+#     shutil.rmtree(".snakemake", ignore_errors=True)
 
 # Read in parameters
 references = config["references"] if "references" in config else "Must specify 'references'"


### PR DESCRIPTION
* Commented out code for deleting snakemake metadata files so those logs are available for users to look at post-run
  * Commented out vs. deleted so it would be easy for an advanced user to re-introduce the code if they want less file clutter post-run