### PR TITLE
Ensure that first synteny block has reason "None"

### DIFF
--- a/bin/ntsynt_synteny.py
+++ b/bin/ntsynt_synteny.py
@@ -455,6 +455,7 @@ class NtSyntSynteny(ntjoin.Ntjoin):
         "Merge collinear blocks that are less than threshold apart, and are not indels"
         out_blocks = []
         curr_block = blocks[0]
+        curr_block.broken_reason = None
         for block in blocks[1:]:
             orientations = True # Are the orientations all the same?
             contig_id = True # Are the contig IDs all the same?


### PR DESCRIPTION
- If smaller synteny blocks were filtered out after a previous round of merging, the first block could erroneously have a reason for discontinuity other than "None"
  - Discontinuity reasons are always determined by the reason for breaking between the previous and current synteny block