### PR TITLE
Add checks and error handling for edge cases

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,6 +36,16 @@ jobs:
 
   - script: |
       source activate ntsynt_ci
+      python3 -c 'import btllib'
+      echo "CONDA_PREFIX=$CONDA_PREFIX"
+      echo "CC=$CC"
+      echo "CXX=$CXX"
+      echo "CPPFLAGS=$CPPFLAGS"
+      echo "CXXFLAGS=$CXXFLAGS"
+      echo "LDFLAGS=$LDFLAGS"
+      command -v c++
+      find "$CONDA_PREFIX/etc/conda/activate.d" -maxdepth 1 -type f -print
+      conda list | grep -E '(^compilers|^cxx-compiler|^gxx_linux-64|^gxx_impl_linux-64)'
       meson setup build --prefix=$(pwd)/ntSynt_build
       cd build
       ninja install

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,7 +31,7 @@ jobs:
   - script: |
       source activate ntsynt_ci
       mamba install --yes -c bioconda -c conda-forge python=3.12
-      MAMBA_USE_SHARDED_REPODATA=OFF mamba install --yes -c bioconda -c conda-forge intervaltree pybedtools ncls 'python-igraph>=1.0.0' compilers btllib meson ninja snakemake samtools pytest seqtk pylint
+      MAMBA_USE_SHARDED_REPODATA=OFF mamba install --yes -c bioconda -c conda-forge intervaltree pybedtools ncls 'python-igraph>=1.0.0' compilers cxx-compiler btllib meson ninja snakemake samtools pytest seqtk pylint
     displayName: Install dependencies
 
   - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,15 +37,7 @@ jobs:
   - script: |
       source activate ntsynt_ci
       python3 -c 'import btllib'
-      echo "CONDA_PREFIX=$CONDA_PREFIX"
-      echo "CC=$CC"
-      echo "CXX=$CXX"
-      echo "CPPFLAGS=$CPPFLAGS"
       echo "CXXFLAGS=$CXXFLAGS"
-      echo "LDFLAGS=$LDFLAGS"
-      command -v c++
-      find "$CONDA_PREFIX/etc/conda/activate.d" -maxdepth 1 -type f -print
-      conda list | grep -E '(^compilers|^cxx-compiler|^gxx_linux-64|^gxx_impl_linux-64)'
       meson setup build --prefix=$(pwd)/ntSynt_build
       cd build
       ninja install

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,7 +31,7 @@ jobs:
   - script: |
       source activate ntsynt_ci
       mamba install --yes -c bioconda -c conda-forge python=3.12
-      MAMBA_USE_SHARDED_REPODATA=OFF mamba install --yes -c bioconda -c conda-forge intervaltree pybedtools ncls 'python-igraph>=1.0.0' compilers cxx-compiler btllib meson ninja snakemake samtools pytest seqtk pylint
+      MAMBA_USE_SHARDED_REPODATA=OFF mamba install --yes -c bioconda -c conda-forge intervaltree pybedtools ncls 'python-igraph>=1.0.0' compilers gxx_linux-64 btllib meson ninja snakemake samtools pytest seqtk pylint
     displayName: Install dependencies
 
   - script: |

--- a/bin/ntSynt
+++ b/bin/ntSynt
@@ -165,7 +165,7 @@ def main():
 
     args.w_rounds = " ".join(map(str, args.w_rounds))
     command = f"snakemake -s {base_dir}/ntsynt_run_pipeline.smk -p --cores {args.t} " \
-                f"--config references='{fastas_input}' kmer={args.k} window={args.w} threads={args.t} fpr={args.fpr} " \
+                f"--config references=\"{fastas_input}\" kmer={args.k} window={args.w} threads={args.t} fpr={args.fpr} " \
                 f"prefix={args.prefix} w_rounds='{args.w_rounds}' indel_merge={args.indel} " \
                 f"collinear_merge={args.merge} block_size={args.block_size} hashes={args.hashes} "
     command += "common=False " if args.no_common else "common=True "

--- a/bin/ntsynt_merge_collinear.py
+++ b/bin/ntsynt_merge_collinear.py
@@ -121,6 +121,9 @@ def merge_collinear_blocks(blocks: list[SyntenyBlock],
       '+': curr.end   = next.end    (extend rightward)
       '-': curr.start = next.start  (extend leftward)
     """
+    if not blocks:
+        return []
+
     out_blocks: list[SyntenyBlock] = []
     curr_block = blocks[0]
 

--- a/bin/ntsynt_synteny.py
+++ b/bin/ntsynt_synteny.py
@@ -454,6 +454,8 @@ class NtSyntSynteny(ntjoin.Ntjoin):
     def merge_collinear_blocks(self, blocks):
         "Merge collinear blocks that are less than threshold apart, and are not indels"
         out_blocks = []
+        if not blocks:
+            return out_blocks
         curr_block = blocks[0]
         curr_block.broken_reason = None
         for block in blocks[1:]:

--- a/src/ntsynt_make_common_bf.cpp
+++ b/src/ntsynt_make_common_bf.cpp
@@ -151,6 +151,14 @@ main(int argc, const char** argv)
       genome, btllib::SeqReader::Flag::LONG_MODE, num_threads);
     #pragma omp parallel
     for (const auto record : reader) {
+      if (record.seq.length() < k) {
+        btllib::log_error(
+          "Record " + record.id + " in genome " + genome +
+          " is shorter than the k-mer size (" + std::to_string(k) +
+          "). Please ensure all input sequences are "
+          "larger than the set k, filtering the input genome file if needed.");
+        exit(1);
+      }
       btllib::NtHash nthash(record.seq, hashes, k);
       while (nthash.roll()) {
         if (bf->contains(nthash.hashes())) {


### PR DESCRIPTION
- Use double quotes around `references` parameter - was reported as a fix by users (#68 ; #92 )
- If any sequences are less than `k`, detect and print a more informative error message
- Check if there are no paths before collinear merging
- Fix for CI